### PR TITLE
ramips: add support for Creality WB-01

### DIFF
--- a/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
+++ b/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "creality,wb-01", "mediatek,mt7628an-soc";
+	model = "Creality WB-01";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-upgrade = &led_status;
+		led-running = &led_status;
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_status: status {
+			label = "green:status";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		sd {
+			label = "red:sd";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "p3led_an", "p1led_an", "p0led_an", "wled_an";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -6,6 +6,26 @@ include ./common-tp-link.mk
 
 DEFAULT_SOC := mt7628an
 
+define Build/creality_wb-01-factory
+  echo '#!/bin/sh' > $@.install.sh
+  echo 'kernel_size=851968' >> $@.install.sh
+  echo 'file=$$2/factory.bin' >> $@.install.sh
+  echo 'file_size=$$(wc -c < $$file)' >> $@.install.sh
+  echo 'fs_size=$$((file_size - kernel_size))' >> $@.install.sh
+  echo 'mtd_write -o 0 -l $$kernel_size write $$file Kernel' \
+    >> $@.install.sh
+  echo 'mtd_write -r -o $$kernel_size -l $$fs_size write $$file RootFS' \
+    >> $@.install.sh
+
+  tar cjf $@.tar.bz2 -C $(dir $@)  \
+    --transform="flags=r;s|$(notdir $@.install.sh)|install.sh|" \
+    --transform="flags=r;s|$(notdir $@)|factory.bin|" \
+    $(notdir $@ $@.install.sh) \
+
+  mv $@.tar.bz2 $@
+  rm $@.install.sh
+endef
+
 define Build/elecom-header
 	$(eval model_id=$(1))
 	( \
@@ -132,6 +152,16 @@ define Device/comfast_cf-wr758ac-v2
   SUPPORTED_DEVICES += joowin,jw-wr758ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr758ac-v2
+
+define Device/creality_wb-01
+  IMAGE_SIZE := 16064k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | creality_wb-01-factory
+  DEVICE_VENDOR := Creality
+  DEVICE_MODEL := WB-01
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += creality_wb-01
 
 define Device/cudy_wr1000
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -19,6 +19,9 @@ netgear,r6120)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0xf"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+creality,wb-01)
+	ucidef_set_led_netdev "lan" "lan" "blue:lan" "eth0"
+	;;
 cudy,wr1000)
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
 	ucidef_set_led_switch "lan1" "lan1" "blue:lan1" "switch0" "0x08"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ ramips_setup_interfaces()
 
 	case $board in
 	alfa-network,awusfree1|\
+	creality,wb-01|\
 	d-team,pbr-d1|\
 	dlink,dap-1325-a1|\
 	glinet,microuter-n300|\
@@ -191,6 +192,14 @@ ramips_setup_macs()
 		lan_mac=$wan_mac
 		label_mac=$wan_mac
 		;;
+	creality,wb-01|\
+	onion,omega2|\
+	onion,omega2p|\
+	vocore,vocore2|\
+	vocore,vocore2-lite|\
+	wavlink,wl-wn576a2)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
 	cudy,wr1000|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
@@ -235,13 +244,6 @@ ramips_setup_macs()
 	motorola,mwr03)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		wan_mac=$(macaddr_add "$label_mac" 2)
-		;;
-	onion,omega2|\
-	onion,omega2p|\
-	vocore,vocore2|\
-	vocore,vocore2-lite|\
-	wavlink,wl-wn576a2)
-		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	rakwireless,rak633|\
 	unielec,u7628-01-16m|\


### PR DESCRIPTION
The Creality WB-01 (unhelpfully referred to interchangably as the "Creality Wifi Box" or simply the "Creality Box") is a device intended to interface Creality brand 3D printers to a cloud service.

Specifications:

- SoC: MediaTek MT7688AN @ 580 MHz
- Flash: BoyaMicro BY25Q128AS (16 MiB, SPI NOR) Seems to be a clone/rebrand of the BoHong BH25Q128AS chip (or vice versa), support for which was added in commit 51b61fd57
- RAM: 128 MiB DDR2 (Winbond W971GG6SB-25)
- Peripheral: Genesys Logic GL850G 2 port USB 2.0 hub
- I/O: 1x 10/100 Ethernet port, microSD SD-XC Class 10 slot, 4x LEDs, 2x USB 2.0 ports, micro USB input (for power only), reset button
- FCC ID: 2AXH6CREALITY-BOX
- UART: test pads: (square on silkscreen) 3V3, TX, RX, GND

LEDs:
40 red    - microSD presence (OpenWrt has no function for this I think)
42 green  - "Cloud service or network configuration indicator"
43 blue   - Ethernet
44 yellow - Wi-Fi

Reset button = 38
SD presence switch = 23

MAC addresses:
factory+0x04 wlan and label MAC
factory+0x28 eth0
factory+0x2e has fc:ee:e6:xx:xx:xx here, but it appears to be unused

Stock firmware /proc/mtd
dev:    size   erasesize  name
mtd0: 01000000 00010000 "ALL"
mtd1: 00030000 00010000 "Bootloader"
mtd2: 00010000 00010000 "Config"
mtd3: 00010000 00010000 "Factory"
mtd4: 000d0000 00010000 "Kernel"
mtd5: 00ee0000 00010000 "RootFS"

Flashing:
1) Rename factory.bin to cxsw_update.tar.bz2
2) Copy it to the root of a FAT32 formatted microSD card. 3) Turn on the device, wait for it to start, then insert the card. The stock firmware reads the install.sh script from this archive, the build script I added creates one that works in a similar way.

Stock firmware can be downloaded from here:
http://file2-cdn.creality.com/model/cfg/box/latest/cxsw_update.tar.bz2 (source: https://forum.creality.com/topic/1701/ )
Stock firmware supports telnet root@10.10.10.254, password cxswprin

Recovery:
1) Add a file called root_uImage to the root of a FAT32 formatted
   USB drive (tip: a microSD to USB adapter works, as included with
   many Creality printers)
   You can find root_uImage in the stock firmware or you can rename
   sysupgrade.bin.
2) Hold the reset pinhole switch and plug in the device. 3) Keep holding reset for 5 seconds, then release. 4) Wait for the lights to stop flashing.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
